### PR TITLE
fix directories always being created in /root if '~/' was used in config_dir

### DIFF
--- a/tasks/raspberry-monitoring.yml
+++ b/tasks/raspberry-monitoring.yml
@@ -14,7 +14,6 @@
     state: directory
     mode: 0755
   with_items:
-    - "{{ config_dir }}/raspberry-monitoring"
     - "{{ config_dir }}/raspberry-monitoring/init"
     - "{{ config_dir }}/raspberry-monitoring/data"
   become: false

--- a/tasks/raspberry-monitoring.yml
+++ b/tasks/raspberry-monitoring.yml
@@ -12,10 +12,12 @@
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory
-    mode: 0644
+    mode: 0755
   with_items:
+    - "{{ config_dir }}/raspberry-monitoring"
     - "{{ config_dir }}/raspberry-monitoring/init"
     - "{{ config_dir }}/raspberry-monitoring/data"
+  become: false
 
 - name: Copy templated raspberry-monitoring files into place.
   ansible.builtin.template:


### PR DESCRIPTION
Permissions are also modified to allow switching into these folders (same as other directories)